### PR TITLE
Fix collision with artifactory plugin

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -5,8 +5,8 @@
         <vendor name="JFrog" url="https://www.jfrog.com"/>
         <param name="plugin-icon">images/jfrogLogo.png</param>
         <param name="plugin-logo">images/jfrogLogo.png</param>
-        <param name="configure.url">/admin/jfrogConfiguration.action</param>
-        <param name="post.install.url">/admin/jfrogConfiguration.action</param>
+        <param name="configure.url">/admin/jfrog/jfrogConfiguration.action</param>
+        <param name="post.install.url">/admin/jfrog/jfrogConfiguration.action</param>
     </plugin-info>
 
     <taskType key="JfTask" name="JFrog CLI Task" class="org.jfrog.bamboo.JfTask">
@@ -26,11 +26,11 @@
 
     <web-item key="configureJfrogPlugin" name="JFrog Configuration" section="system.admin/plugins">
         <label key="JFrog Configuration"/>
-        <link linkId="configureJfrogPlugin">/admin/jfrogConfiguration.action</link>
+        <link linkId="configureJfrogPlugin">/admin/jfrog/jfrogConfiguration.action</link>
     </web-item>
 
     <xwork key="jfrogConfigAdmin" name="JFrog Configuration">
-        <package name="configureJfrogPlugin" extends="admin">
+        <package name="configureJfrogPlugin" extends="admin" namespace="/admin/jfrog">
 
             <!-- Main container -->
             <action name="jfrogConfiguration" class="org.jfrog.bamboo.config.JfrogConfigurationAction">
@@ -51,7 +51,7 @@
 
             <action name="createJfrogServer" class="org.jfrog.bamboo.config.JfrogServerConfigAction" method="doCreate">
                 <result name="input" type="freemarker">/templates/jfrogServerConfig.ftl</result>
-                <result name="success" type="redirect">/admin/jfrogConfiguration.action</result>
+                <result name="success" type="redirect">/admin/jfrog/jfrogConfiguration.action</result>
                 <result name="error" type="freemarker">/templates/jfrogServerConfig.ftl</result>
                 <param name="mode">add</param>
             </action>
@@ -63,7 +63,7 @@
 
             <action name="updateServer" class="org.jfrog.bamboo.config.JfrogServerConfigAction" method="update">
                 <result name="input" type="freemarker">/templates/jfrogServerConfig.ftl</result>
-                <result name="success" type="redirect">/admin/jfrogConfiguration.action</result>
+                <result name="success" type="redirect">/admin/jfrog/jfrogConfiguration.action</result>
                 <param name="mode">edit</param>
             </action>
 
@@ -74,8 +74,8 @@
 
             <action name="deleteServer" class="org.jfrog.bamboo.config.JfrogServerConfigAction" method="delete">
                 <result name="input" type="redirect">/templates/jfrogServerConfig.ftl</result>
-                <result name="success" type="redirect">/admin/jfrogConfiguration.action</result>
-                <result name="error" type="redirect">/admin/jfrogConfiguration.action</result>
+                <result name="success" type="redirect">/admin/jfrog/jfrogConfiguration.action</result>
+                <result name="error" type="redirect">/admin/jfrog/jfrogConfiguration.action</result>
             </action>
 
         </package>

--- a/src/main/resources/templates/confirmDeleteServer.ftl
+++ b/src/main/resources/templates/confirmDeleteServer.ftl
@@ -1,5 +1,5 @@
 <title>[@ww.text name="jfrogServer.delete" /]</title>
-[@ww.form action="deleteServer" namespace="/admin"
+[@ww.form action="deleteServer" namespace="/admin/jfrog"
 submitLabelKey="global.buttons.delete"
 id="confirmDelete"]
     [@s.hidden name="returnUrl" /]

--- a/src/main/resources/templates/jfrogServerConfig.ftl
+++ b/src/main/resources/templates/jfrogServerConfig.ftl
@@ -11,9 +11,9 @@
 <body>
 [/#if]
 
-[#assign cancelUri = '/admin/jfrogConfiguration.action' /]
+[#assign cancelUri = '/admin/jfrog/jfrogConfiguration.action' /]
 
-[@ww.form action=targetAction id="myform" title='JFrog Platform Configuration' submitLabelKey='global.buttons.update' cancelUri='/admin/jfrogConfiguration.action' showActionErrors='true']
+[@ww.form action=targetAction id="myform" title='JFrog Platform Configuration' submitLabelKey='global.buttons.update' cancelUri='/admin/jfrog/jfrogConfiguration.action' showActionErrors='true']
     [@ww.param name='buttons']
         [@ww.submit value="Test Connection" name="testConnection" /]
     [/@ww.param]

--- a/src/main/resources/templates/viewExistingServersList.ftl
+++ b/src/main/resources/templates/viewExistingServersList.ftl
@@ -3,7 +3,7 @@
         <ul class="toolbar-group">
             <li class="toolbar-item">
                 <a class="toolbar-trigger"
-                   href="[@s.url action='jfrogServerConfig' namespace='/admin' /]">
+                   href="[@s.url action='jfrogServerConfig' namespace='/admin/jfrog' /]">
                     [@ww.text name="New JFrog Platform Configuration" /]</a>
             </li>
         </ul>
@@ -38,12 +38,12 @@
                         </td>
                         <td class="operations">
                             <a id="editServer-${serverConfig.serverId}"
-                               href="[@ww.url action='editServer' serverId=serverConfig.serverId/]">
+                               href="[@ww.url action='editServer' namespace='/admin/jfrog' serverId=serverConfig.serverId/]">
                                 Edit
                             </a>
                             |
                             <a id="deleteServer-${serverConfig.serverId}"
-                               href="[@ww.url action='confirmDeleteServer' serverId=serverConfig.serverId returnUrl=currentUrl/]"
+                               href="[@ww.url action='confirmDeleteServer' namespace='/admin/jfrog' serverId=serverConfig.serverId returnUrl=currentUrl/]"
                                class="delete" title="[@ww.text name="Delete JFrog Platform Configuration" /]">
                                 Delete
                             </a>


### PR DESCRIPTION
Problem :- Here the both the plugin were registering to same endpoints for the admin configuration, hence the whichever plugin was loaded later, has overwritten the routes of existing one, hence this was causing the issue.

fix :- new namespaces are introduced and routes are being modified.